### PR TITLE
Rename Sh*t to Shoot

### DIFF
--- a/App/App.js
+++ b/App/App.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/App.test.js
+++ b/App/App.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React from 'react';

--- a/App/BackButton/BackButton.js
+++ b/App/BackButton/BackButton.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import PropTypes from 'prop-types';

--- a/App/BackButton/index.js
+++ b/App/BackButton/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import BackButton from './BackButton';

--- a/App/Footer/About/About.js
+++ b/App/Footer/About/About.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Footer/About/index.js
+++ b/App/Footer/About/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import About from './About';

--- a/App/Footer/Footer.js
+++ b/App/Footer/Footer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import PropTypes from 'prop-types';

--- a/App/Footer/index.js
+++ b/App/Footer/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Footer from './Footer';

--- a/App/Header/Header.js
+++ b/App/Header/Header.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Header/index.js
+++ b/App/Header/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Header from './Header';

--- a/App/Screens/ErrorScreen/ErrorScreen.js
+++ b/App/Screens/ErrorScreen/ErrorScreen.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import PropTypes from 'prop-types';

--- a/App/Screens/ErrorScreen/index.js
+++ b/App/Screens/ErrorScreen/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import ErrorScreen from './ErrorScreen';

--- a/App/Screens/Home/Cigarettes/Cigarette/Cigarette.js
+++ b/App/Screens/Home/Cigarettes/Cigarette/Cigarette.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Screens/Home/Cigarettes/Cigarette/index.js
+++ b/App/Screens/Home/Cigarettes/Cigarette/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Cigarette from './Cigarette';

--- a/App/Screens/Home/Cigarettes/Cigarettes.js
+++ b/App/Screens/Home/Cigarettes/Cigarettes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Screens/Home/Cigarettes/index.js
+++ b/App/Screens/Home/Cigarettes/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Cigarettes from './Cigarettes';

--- a/App/Screens/Home/Home.js
+++ b/App/Screens/Home/Home.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';
@@ -39,10 +39,11 @@ export default class Home extends Component {
 
   handleShare = () =>
     Share.share({
-      title:
-        'Did you know that you may be smoking up to 20 cigarettes per day, just for living in a big city?',
+      title: `Shoot! I 'smoked' ${pm25ToCigarettes(
+        this.props.screenProps.api
+      )} cigarettes today by breathing urban air. How much did you smoke? shootismoke.github.io`,
       message:
-        'Sh*t! I Smoke is an application that tells you how many cigarettes you smoke based on the pollution levels of your city. Download it for free here! shitismoke.github.io'
+        'Shoot! I Smoke is an application that tells you how many cigarettes you smoke based on the pollution levels of your city. Download it for free here! shootismoke.github.io'
     });
 
   render() {

--- a/App/Screens/Home/Home.js
+++ b/App/Screens/Home/Home.js
@@ -39,11 +39,11 @@ export default class Home extends Component {
 
   handleShare = () =>
     Share.share({
-      title: `Shoot! I 'smoked' ${pm25ToCigarettes(
+      title:
+        'Did you know that you may be smoking up to 20 cigarettes per day, just for living in a big city?',
+      message: `Shoot! I 'smoked' ${pm25ToCigarettes(
         this.props.screenProps.api
-      )} cigarettes today by breathing urban air. How much did you smoke? shootismoke.github.io`,
-      message:
-        'Shoot! I Smoke is an application that tells you how many cigarettes you smoke based on the pollution levels of your city. Download it for free here! shootismoke.github.io'
+      )} cigarettes today by breathing urban air. And you? Find out here: shootismoke.github.io`
     });
 
   render() {

--- a/App/Screens/Home/index.js
+++ b/App/Screens/Home/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Home from './Home';

--- a/App/Screens/Loading/Background.js
+++ b/App/Screens/Loading/Background.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Screens/Loading/Loading.js
+++ b/App/Screens/Loading/Loading.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import PropTypes from 'prop-types';

--- a/App/Screens/Loading/index.js
+++ b/App/Screens/Loading/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Loading from './Loading';

--- a/App/Screens/MapScreen/MapScreen.js
+++ b/App/Screens/MapScreen/MapScreen.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Screens/MapScreen/index.js
+++ b/App/Screens/MapScreen/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import MapScreen from './MapScreen';

--- a/App/Screens/Screens.js
+++ b/App/Screens/Screens.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Screens/Search/Item/Item.js
+++ b/App/Screens/Search/Item/Item.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Screens/Search/Item/index.js
+++ b/App/Screens/Search/Item/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Item from './Item';

--- a/App/Screens/Search/Search.js
+++ b/App/Screens/Search/Search.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Screens/Search/SearchHeader/SearchHeader.js
+++ b/App/Screens/Search/SearchHeader/SearchHeader.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import React, { Component } from 'react';

--- a/App/Screens/Search/SearchHeader/index.js
+++ b/App/Screens/Search/SearchHeader/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import SearchHeader from './SearchHeader';

--- a/App/Screens/Search/index.js
+++ b/App/Screens/Search/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Search from './Search';

--- a/App/Screens/index.js
+++ b/App/Screens/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import Screens from './Screens';

--- a/App/index.js
+++ b/App/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import App from './App';

--- a/App/utils/getCorrectLatLng.js
+++ b/App/utils/getCorrectLatLng.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 /**

--- a/App/utils/getCurrentPosition.js
+++ b/App/utils/getCurrentPosition.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 /**

--- a/App/utils/pm25ToCigarettes.js
+++ b/App/utils/pm25ToCigarettes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 /**

--- a/App/utils/theme.js
+++ b/App/utils/theme.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, Amaury Martiny and the Sh*t! I Smoke contributors
+// Copyright (c) 2018, Amaury Martiny and the Shoot! I Smoke contributors
 // SPDX-License-Identifier: GPL-3.0
 
 import { Constants } from 'expo';

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Know how many cigarettes you smoke based on the pollution of your location.
 
-[![app-store](https://shitismoke.github.io/assets/images/app-store.png)](https://itunes.apple.com/us/app/s-i-smoke/id1365605567?mt=8) [![google-play](https://shitismoke.github.io/assets/images/play-store.png)](https://play.google.com/store/apps/details?id=com.shitismoke.app)
+[![app-store](https://shootismoke.github.io/assets/images/app-store.png)](https://itunes.apple.com/us/app/s-i-smoke/id1365605567?mt=8) [![google-play](https://shootismoke.github.io/assets/images/play-store.png)](https://play.google.com/store/apps/details?id=com.shitismoke.app)
 
 ## Screenshots
 
@@ -12,10 +12,10 @@ Know how many cigarettes you smoke based on the pollution of your location.
 
 This app is bootstrapped with [Expo](https://expo.io), you can download the Expo app on the [App Store](https://itunes.apple.com/us/app/expo-client/id982107779) or [Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent), and enter the url provided below. We have 2 release channels:
 
-| Release Channel | Description                                                                 | Url                                                                       |
-| --------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Production      | Same version as Sh\*t! I Smoke on the App Store and Play Store.             | `https://exp.host/@amaurymartiny/shit-i-smoke?release-channel=production` |
-| Staging         | Latest version currently in development: newest features, may contain bugs. | `https://exp.host/@amaurymartiny/shit-i-smoke`                            |
+| Release Channel | Description                                                                 | Url                                                                        |
+| --------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Production      | Same version as Sh\*t! I Smoke on the App Store and Play Store.             | `https://exp.host/@amaurymartiny/shoot-i-smoke?release-channel=production` |
+| Staging         | Latest version currently in development: newest features, may contain bugs. | `https://exp.host/@amaurymartiny/shoot-i-smoke`                            |
 
 ## Contribute
 
@@ -38,8 +38,8 @@ Before developing the app, you need to fetch your own API tokens for the followi
 Then run the following commands:
 
 ```bash
-git clone https://github.com/amaurymartiny/shit-i-smoke
-cd shit-i-smoke
+git clone https://github.com/amaurymartiny/shoot-i-smoke
+cd shoot-i-smoke
 yarn install
 
 cp app.example.json app.json # Replace the API keys placeholders with your own tokens in app.json

--- a/app.example.json
+++ b/app.example.json
@@ -13,14 +13,14 @@
     "extra": {
       "algoliaApiKey": "YOUR_API_KEY",
       "algoliaApplicationId": "YOUR_APPLICATION_ID",
-      "githubUrl": "https://github.com/amaurymartiny/shit-i-smoke",
+      "githubUrl": "https://github.com/amaurymartiny/shoot-i-smoke",
       "googleGeocodingApiKey": "YOU_API_KEY",
       "waqiToken": "YOUR_API_KEY"
     },
-    "githubUrl": "https://github.com/amaurymartiny/shit-i-smoke",
+    "githubUrl": "https://github.com/amaurymartiny/shoot-i-smoke",
     "icon": "assets/logos/ios/iTunesArtwork@3x.png",
     "ios": {
-      "buildNumber": "1.1.1",
+      "buildNumber": "1.1.2",
       "bundleIdentifier": "com.shitismoke.app",
       "config": {
         "googleMapsApiKey": "YOUR_API_KEY"
@@ -32,15 +32,15 @@
       },
       "loadJSInBackgroundExperimental": true
     },
-    "name": "Sh*t! I Smoke",
+    "name": "Shoot! I Smoke",
     "primaryColor": "#EBE7DD",
     "privacy": "public",
     "sdkVersion": "27.0.0",
-    "slug": "shit-i-smoke",
+    "slug": "shoot-i-smoke",
     "splash": {
       "backgroundColor": "#ebe7dd",
       "image": "assets/logos/splash.png"
     },
-    "version": "1.1.1"
+    "version": "1.1.2"
   }
 }

--- a/app.example.json
+++ b/app.example.json
@@ -7,7 +7,7 @@
       "icon": "assets/logos/android/playstore-icon.png",
       "package": "com.shitismoke.app",
       "permissions": ["ACCESS_FINE_LOCATION"],
-      "versionCode": 2
+      "versionCode": 4
     },
     "assetBundlePatterns": ["assets/fonts/*"],
     "extra": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "shit-i-smoke",
-  "version": "0.1.1",
+  "name": "shoot-i-smoke",
+  "version": "1.1.2",
   "main": "node_modules/expo/AppEntry.js",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Because it got rejected on the Play Store.

Closes #4 .