### PR TITLE
feat: Share android image (#247)

### DIFF
--- a/App/Screens/Home/Footer/Footer.tsx
+++ b/App/Screens/Home/Footer/Footer.tsx
@@ -15,7 +15,7 @@
 // along with Sh**t! I Smoke.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useContext } from 'react';
-import { Platform, Share, StyleSheet, View, ViewProps } from 'react-native';
+import { StyleSheet, View, ViewProps } from 'react-native';
 import { NavigationInjectedProps } from 'react-navigation';
 
 import { aboutSections } from '../../About';
@@ -56,17 +56,7 @@ export function Footer (props: FooterProps) {
   function handleShare () {
     track('HOME_SCREEN_SHARE_CLICK');
 
-    // Share doesn't currently support images on Android, so the text version
-    if (Platform.OS === 'ios') {
-      props.navigation.navigate('ShareModal');
-    } else {
-      Share.share({
-        title: i18n.t('home_share_title'),
-        message: i18n.t('home_share_message', {
-          cigarettes: api!.shootISmoke.cigarettes.toFixed(2)
-        })
-      });
-    }
+    props.navigation.navigate('ShareModal');
   }
 
   const renderBigButton = () => {

--- a/App/Screens/ShareScreen/ShareScreen.tsx
+++ b/App/Screens/ShareScreen/ShareScreen.tsx
@@ -15,9 +15,10 @@
 // along with Sh**t! I Smoke.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useEffect, createRef } from 'react';
-import { Share, StyleSheet, View } from 'react-native';
+import { Share, StyleSheet, View, Platform } from 'react-native';
 import { captureRef } from 'react-native-view-shot';
 import { NavigationInjectedProps } from 'react-navigation';
+import * as Sharing from 'expo-sharing';
 
 import { ShareImage } from './ShareImage';
 import { i18n } from '../../localization';
@@ -37,9 +38,15 @@ export function ShareScreen (props: ShareScreenProps) {
           quality: 1
         });
 
-        await Share.share({
-          url: uri
-        });
+        if (Platform.OS === 'ios') {
+          await Share.share({
+            url: uri
+          });
+        } else {
+          await Sharing.shareAsync(uri, {
+            mimeType: 'image/png'
+          });
+        }
       } catch (error) {}
 
       handleDismiss();


### PR DESCRIPTION
Extract share logic to share screen.
For Android sharing use [expo-sharing](https://docs.expo.io/versions/latest/sdk/sharing).
For iOS keep old sharing algorithm to avoid breaking changes.
For testing use telegram.

fixes #247 