### PR TITLE
fix: Add sentry logs on errors (backport #269)

### DIFF
--- a/App/Screens/About/About.tsx
+++ b/App/Screens/About/About.tsx
@@ -188,7 +188,7 @@ export function About (props: AboutProps) {
           </Text>
           .{'\n'}
           {'\n'}
-          Sh**t! I Smoke v{Constants.manifest.version}.
+          Sh**t! I Smoke v{Constants.manifest.version} (#{Constants.manifest.revisionId || 'development'}).
         </Text>
         {/* Add languages https://github.com/amaurymartiny/shoot-i-smoke/issues/73 */}
       </View>

--- a/App/Screens/ErrorScreen/ErrorScreen.tsx
+++ b/App/Screens/ErrorScreen/ErrorScreen.tsx
@@ -14,10 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Sh**t! I Smoke.  If not, see <http://www.gnu.org/licenses/>.
 
-import React, { useContext } from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import React, { useContext, useEffect } from 'react';
 import { NavigationInjectedProps } from 'react-navigation';
+import { Image, StyleSheet, Text, View } from 'react-native';
 import { scale } from 'react-native-size-matters';
+import * as Sentry from 'sentry-expo';
 
 import errorPicture from '../../../assets/images/error.png';
 import { Button } from '../../components';
@@ -32,6 +33,12 @@ export function ErrorScreen (props: ErrorScreenProps) {
   const { error } = useContext(ErrorContext);
 
   trackScreen('ERROR');
+
+  useEffect(() => {
+    if (error) {
+      Sentry.captureException(new Error(error));
+    }
+  }, []);
 
   return (
     <View style={styles.container}>

--- a/App/util/fp.ts
+++ b/App/util/fp.ts
@@ -21,7 +21,7 @@ import * as TE from 'fp-ts/lib/TaskEither';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { capDelay, limitRetries, RetryStatus } from 'retry-ts';
 import { retrying } from 'retry-ts/lib/Task';
-import Sentry from 'sentry-expo';
+import * as Sentry from 'sentry-expo';
 
 import { noop } from './noop';
 


### PR DESCRIPTION
* fix: Add sentry logs on errors

* Only track sentry on mount

* Add revisionId in about