### PR TITLE
fix: Force status bar style to be dark content in iOS

### DIFF
--- a/App/App.tsx
+++ b/App/App.tsx
@@ -17,7 +17,7 @@
 import * as Font from 'expo-font';
 import Constants from 'expo-constants';
 import React, { useEffect, useState } from 'react';
-import { AppState } from 'react-native';
+import { AppState, StatusBar, Platform } from 'react-native';
 import * as Sentry from 'sentry-expo';
 
 import { Screens } from './Screens';
@@ -75,6 +75,9 @@ export function App() {
         <ApiContextProvider>
           <FrequencyContextProvider>
             <DistanceUnitProvider>
+              {Platform.select({
+                ios: <StatusBar barStyle="dark-content" />
+              })}
               <Screens />
             </DistanceUnitProvider>
           </FrequencyContextProvider>

--- a/App/App.tsx
+++ b/App/App.tsx
@@ -17,7 +17,7 @@
 import * as Font from 'expo-font';
 import Constants from 'expo-constants';
 import React, { useEffect, useState } from 'react';
-import { AppState, StatusBar, Platform } from 'react-native';
+import { AppState, Platform, StatusBar } from 'react-native';
 import * as Sentry from 'sentry-expo';
 
 import { Screens } from './Screens';


### PR DESCRIPTION
Tested in iOS 12.4 and 13.2, both the status bar font color is white, so this is for forcing it to be black as the background color is light color.
I did it specifically for iOS because saw that some Androids have dark background in the status bar, therefore it's better to keep the automatic behavior.

It's good to note that in development, using Expo App, the status bar is always black, but production version has white color.

# Before
![imagem](https://user-images.githubusercontent.com/3604271/67529147-b8a4a700-f691-11e9-8783-6ff13de00d94.png)

# After
![imagem](https://user-images.githubusercontent.com/3604271/67529197-cf4afe00-f691-11e9-8ad4-e9cb49beee56.png)
