### PR TITLE
chore: Eslint sort import rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,8 +9,9 @@ module.exports = {
     'plugin:prettier/recommended'
   ],
   parser: '@typescript-eslint/parser',
-  plugins: ['react', '@typescript-eslint', 'prettier'],
+  plugins: ['react', '@typescript-eslint', 'prettier', 'simple-import-sort'],
   rules: {
+    'simple-import-sort/sort': 'error',
     // disable the rule for all files
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off'

--- a/App/App.tsx
+++ b/App/App.tsx
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Sh**t! I Smoke.  If not, see <http://www.gnu.org/licenses/>.
 
-import * as Font from 'expo-font';
 import Constants from 'expo-constants';
+import * as Font from 'expo-font';
 import React, { useEffect, useState } from 'react';
 import { AppState, Platform, StatusBar } from 'react-native';
 import * as Sentry from 'sentry-expo';

--- a/App/Screens/About/About.tsx
+++ b/App/Screens/About/About.tsx
@@ -28,6 +28,7 @@ import {
 import { ScrollIntoView, wrapScrollView } from 'react-native-scroll-into-view';
 import { scale } from 'react-native-size-matters';
 import { NavigationInjectedProps } from 'react-navigation';
+
 import { BackButton } from '../../components';
 import { i18n } from '../../localization';
 import { useDistanceUnit } from '../../stores/distanceUnit';

--- a/App/Screens/About/Box/Box.tsx
+++ b/App/Screens/About/Box/Box.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { Image, Platform, StyleSheet, Text, View } from 'react-native';
 import { scale } from 'react-native-size-matters';
+
 import cigarette from '../../../../assets/images/cigarette.png';
 import { i18n } from '../../../localization';
 import * as theme from '../../../util/theme';

--- a/App/Screens/About/Language/Language.tsx
+++ b/App/Screens/About/Language/Language.tsx
@@ -16,6 +16,7 @@
 
 import React, { useContext } from 'react';
 import { Picker, StyleSheet, Text, View } from 'react-native';
+
 import { i18n } from '../../../localization';
 import { ApiContext } from '../../../stores';
 import * as theme from '../../../util/theme';

--- a/App/Screens/Details/Details.tsx
+++ b/App/Screens/Details/Details.tsx
@@ -19,6 +19,7 @@ import { StyleSheet, View } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import { NavigationInjectedProps } from 'react-navigation';
 import truncate from 'truncate';
+
 import homeIcon from '../../../assets/images/home.png';
 import stationIcon from '../../../assets/images/station.png';
 import { i18n } from '../../localization';

--- a/App/Screens/Details/Distance/Distance.tsx
+++ b/App/Screens/Details/Distance/Distance.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { StyleSheet, Text } from 'react-native';
+
 import { Banner } from '../../../components';
 import { i18n } from '../../../localization';
 import { useDistanceUnit } from '../../../stores/distanceUnit';

--- a/App/Screens/Details/Header/Header.tsx
+++ b/App/Screens/Details/Header/Header.tsx
@@ -25,6 +25,7 @@ import {
   TextStyle,
   View
 } from 'react-native';
+
 import locationIcon from '../../../../assets/images/location.png';
 import { BackButton, CurrentLocation } from '../../../components';
 import { i18n } from '../../../localization';

--- a/App/Screens/ErrorScreen/ErrorScreen.tsx
+++ b/App/Screens/ErrorScreen/ErrorScreen.tsx
@@ -19,6 +19,7 @@ import { Image, StyleSheet, Text, View } from 'react-native';
 import { scale } from 'react-native-size-matters';
 import { NavigationInjectedProps } from 'react-navigation';
 import * as Sentry from 'sentry-expo';
+
 import errorPicture from '../../../assets/images/error.png';
 import { Button } from '../../components';
 import { i18n } from '../../localization';

--- a/App/Screens/Home/AdditionalInfo/AdditionalInfo.tsx
+++ b/App/Screens/Home/AdditionalInfo/AdditionalInfo.tsx
@@ -24,6 +24,7 @@ import {
 } from 'react-native';
 import { scale } from 'react-native-size-matters';
 import { NavigationInjectedProps } from 'react-navigation';
+
 import { i18n } from '../../../localization';
 import { ApiContext, CurrentLocationContext } from '../../../stores';
 import { track } from '../../../util/amplitude';

--- a/App/Screens/Home/Footer/Footer.tsx
+++ b/App/Screens/Home/Footer/Footer.tsx
@@ -17,6 +17,7 @@
 import React, { useContext } from 'react';
 import { StyleSheet, View, ViewProps } from 'react-native';
 import { NavigationInjectedProps } from 'react-navigation';
+
 import { Button } from '../../../components';
 import { i18n } from '../../../localization';
 import { ApiContext, CurrentLocationContext } from '../../../stores';

--- a/App/Screens/Home/Header/Header.tsx
+++ b/App/Screens/Home/Header/Header.tsx
@@ -23,6 +23,7 @@ import {
   View
 } from 'react-native';
 import { scale } from 'react-native-size-matters';
+
 import alert from '../../../../assets/images/alert.png';
 import { ChangeLocation, CurrentLocation } from '../../../components';
 import { i18n } from '../../../localization';

--- a/App/Screens/Home/Home.tsx
+++ b/App/Screens/Home/Home.tsx
@@ -17,6 +17,7 @@
 import React, { useContext } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { NavigationInjectedProps } from 'react-navigation';
+
 import { CigaretteBlock, getCigaretteCount } from '../../components';
 import {
   ApiContext,

--- a/App/Screens/Home/SelectFrequency/SelectFrequency.tsx
+++ b/App/Screens/Home/SelectFrequency/SelectFrequency.tsx
@@ -16,6 +16,7 @@
 
 import React, { useContext, useRef, useState } from 'react';
 import { ScrollView, ScrollViewProps, StyleSheet } from 'react-native';
+
 import { BoxButton } from '../../../components';
 import { i18n } from '../../../localization';
 import { FrequencyContext } from '../../../stores';

--- a/App/Screens/Home/SmokeVideo/SmokeVideo.tsx
+++ b/App/Screens/Home/SmokeVideo/SmokeVideo.tsx
@@ -17,6 +17,7 @@
 import { Video } from 'expo-av';
 import React from 'react';
 import { Dimensions, StyleSheet, View } from 'react-native';
+
 import smokeVideo from '../../../../assets/video/smoke_bg_fafafc.mp4';
 
 interface SmokeVideoProps {

--- a/App/Screens/Loading/Background.tsx
+++ b/App/Screens/Loading/Background.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+
 import * as theme from '../../util/theme';
 
 interface BackgroundProps {

--- a/App/Screens/Loading/Loading.tsx
+++ b/App/Screens/Loading/Loading.tsx
@@ -16,6 +16,7 @@
 
 import React, { useContext, useEffect, useState } from 'react';
 import { StyleSheet, Text } from 'react-native';
+
 import { i18n } from '../../localization';
 import { ApiContext, GpsLocationContext } from '../../stores';
 import { Api } from '../../stores/fetchApi';

--- a/App/Screens/Screens.tsx
+++ b/App/Screens/Screens.tsx
@@ -29,6 +29,7 @@ import {
   NavigationStackProp
 } from 'react-navigation-stack';
 import { fadeIn } from 'react-navigation-transitions';
+
 import { ApiContext, ErrorContext } from '../stores';
 import { Api } from '../stores/fetchApi';
 import * as theme from '../util/theme';

--- a/App/Screens/Search/AlgoliaItem/AlgoliaItem.tsx
+++ b/App/Screens/Search/AlgoliaItem/AlgoliaItem.tsx
@@ -17,8 +17,8 @@
 import React from 'react';
 
 import { ListItem } from '../../../components';
-import { AlgoliaHit } from '../fetchAlgolia';
 import { Location } from '../../../stores/fetchGpsPosition';
+import { AlgoliaHit } from '../fetchAlgolia';
 
 interface ItemProps {
   item: AlgoliaHit;

--- a/App/Screens/Search/Search.tsx
+++ b/App/Screens/Search/Search.tsx
@@ -21,6 +21,7 @@ import React, { useContext, useState } from 'react';
 import { FlatList, StyleSheet, Text, View } from 'react-native';
 import { NavigationInjectedProps } from 'react-navigation';
 import Sentry from 'sentry-expo';
+
 import { BackButton, ListSeparator } from '../../components';
 import { CurrentLocationContext, GpsLocationContext } from '../../stores';
 import { Location } from '../../stores/fetchGpsPosition';

--- a/App/Screens/Search/SearchHeader/SearchHeader.tsx
+++ b/App/Screens/Search/SearchHeader/SearchHeader.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { Image, StyleSheet, TextInput } from 'react-native';
+
 import searchIcon from '../../../../assets/images/search.png';
 import { Banner } from '../../../components';
 import { i18n } from '../../../localization';

--- a/App/Screens/Search/fetchAlgolia.ts
+++ b/App/Screens/Search/fetchAlgolia.ts
@@ -23,6 +23,7 @@ import * as T from 'fp-ts/lib/Task';
 import * as TE from 'fp-ts/lib/TaskEither';
 import * as t from 'io-ts';
 import { failure } from 'io-ts/lib/PathReporter';
+
 import { LatLng } from '../../stores/fetchGpsPosition';
 import { retry, sideEffect, toError } from '../../util/fp';
 

--- a/App/Screens/ShareScreen/ShareImage/ShareImage.tsx
+++ b/App/Screens/ShareScreen/ShareImage/ShareImage.tsx
@@ -16,6 +16,7 @@
 
 import React, { useContext } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+
 import { CigaretteBlock, CurrentLocation } from '../../../components';
 import {
   ApiContext,

--- a/App/Screens/ShareScreen/ShareScreen.tsx
+++ b/App/Screens/ShareScreen/ShareScreen.tsx
@@ -19,6 +19,7 @@ import React, { createRef, useContext, useEffect } from 'react';
 import { Platform, Share, StyleSheet, View } from 'react-native';
 import { captureRef } from 'react-native-view-shot';
 import { NavigationInjectedProps } from 'react-navigation';
+
 import { Button } from '../../components';
 import { i18n } from '../../localization';
 import { ApiContext } from '../../stores';

--- a/App/components/BackButton/BackButton.tsx
+++ b/App/components/BackButton/BackButton.tsx
@@ -25,6 +25,7 @@ import {
   View,
   ViewStyle
 } from 'react-native';
+
 import backIcon from '../../../assets/images/back.png';
 import { i18n } from '../../localization';
 import * as theme from '../../util/theme';

--- a/App/components/Banner/Banner.tsx
+++ b/App/components/Banner/Banner.tsx
@@ -23,6 +23,7 @@ import {
   View,
   ViewStyle
 } from 'react-native';
+
 import * as theme from '../../util/theme';
 
 interface BannerProps {

--- a/App/components/BoxButton/BoxButton.tsx
+++ b/App/components/BoxButton/BoxButton.tsx
@@ -23,6 +23,7 @@ import {
   View
 } from 'react-native';
 import { scale } from 'react-native-size-matters';
+
 import * as theme from '../../util/theme';
 
 interface BoxButtonProps extends TouchableWithoutFeedbackProps {

--- a/App/components/Button/Button.tsx
+++ b/App/components/Button/Button.tsx
@@ -23,6 +23,7 @@ import {
   TouchableOpacityProps
 } from 'react-native';
 import { scale } from 'react-native-size-matters';
+
 import * as theme from '../../util/theme';
 
 interface ButtonProps extends TouchableOpacityProps {

--- a/App/components/ChangeLocation/ChangeLocation.tsx
+++ b/App/components/ChangeLocation/ChangeLocation.tsx
@@ -23,6 +23,7 @@ import {
   TouchableOpacityProps
 } from 'react-native';
 import { scale } from 'react-native-size-matters';
+
 import changeLocation from '../../../assets/images/changeLocation.png';
 import { i18n } from '../../localization';
 import * as theme from '../../util/theme';

--- a/App/components/CigaretteBlock/CigaretteBlock.tsx
+++ b/App/components/CigaretteBlock/CigaretteBlock.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { StyleSheet, Text, View, ViewProps } from 'react-native';
+
 import { i18n } from '../../localization';
 import { Frequency } from '../../Screens/Home/SelectFrequency';
 import * as theme from '../../util/theme';

--- a/App/components/Cigarettes/Cigarette/Cigarette.tsx
+++ b/App/components/Cigarettes/Cigarette/Cigarette.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { Image, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { scale } from 'react-native-size-matters';
+
 import buttVertical from '../../../../assets/images/butt-vertical.png';
 import butt from '../../../../assets/images/butt.png';
 import headVertical from '../../../../assets/images/head-vertical.png';

--- a/App/components/Cigarettes/Cigarettes.tsx
+++ b/App/components/Cigarettes/Cigarettes.tsx
@@ -17,7 +17,8 @@
 import React from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { scale } from 'react-native-size-matters';
-import { Cigarette, CigaretteSize, CIGARETTES_HEIGHT } from './Cigarette';
+
+import { Cigarette, CIGARETTES_HEIGHT, CigaretteSize } from './Cigarette';
 
 interface CigarettesProps {
   cigarettes: number;

--- a/App/components/CurrentLocation/CurrentLocation.tsx
+++ b/App/components/CurrentLocation/CurrentLocation.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { StyleSheet, Text, TextProps } from 'react-native';
+
 import { i18n } from '../../localization';
 import { Api } from '../../stores/fetchApi';
 import { Location } from '../../stores/fetchGpsPosition';

--- a/App/components/ListItem/ListItem.tsx
+++ b/App/components/ListItem/ListItem.tsx
@@ -23,6 +23,7 @@ import {
   TouchableOpacityProps,
   View
 } from 'react-native';
+
 import gpsIcon from '../../../assets/images/location-big.png';
 import pinIcon from '../../../assets/images/location.png';
 import * as theme from '../../util/theme';

--- a/App/components/ListSeparator/ListSeparator.tsx
+++ b/App/components/ListSeparator/ListSeparator.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
+
 import * as theme from '../../util/theme';
 
 const styles = StyleSheet.create({

--- a/App/localization/index.ts
+++ b/App/localization/index.ts
@@ -17,8 +17,8 @@
 import * as Localization from 'expo-localization';
 import i18n from 'i18n-js';
 
-import en from './languages/en.json';
 import enUS from './languages/en-us.json';
+import en from './languages/en.json';
 
 i18n.fallbacks = true;
 i18n.translations = {

--- a/App/stores/api.tsx
+++ b/App/stores/api.tsx
@@ -18,6 +18,7 @@ import { pipe } from 'fp-ts/lib/pipeable';
 import * as T from 'fp-ts/lib/Task';
 import * as TE from 'fp-ts/lib/TaskEither';
 import React, { createContext, useContext, useEffect, useState } from 'react';
+
 import { logFpError } from '../util/fp';
 import { noop } from '../util/noop';
 import { ErrorContext } from './error';

--- a/App/stores/distanceUnit.tsx
+++ b/App/stores/distanceUnit.tsx
@@ -6,6 +6,7 @@ import React, {
   useState
 } from 'react';
 import { AsyncStorage } from 'react-native';
+
 import { i18n } from '../localization';
 
 export type DistanceUnit = 'km' | 'mile';

--- a/App/stores/fetchApi/dataSources/aqicn.ts
+++ b/App/stores/fetchApi/dataSources/aqicn.ts
@@ -17,8 +17,8 @@
 import axios from 'axios';
 import Constants from 'expo-constants';
 
-import { aqiToRaw } from './aqiToRaw';
 import { LatLng } from '../../fetchGpsPosition';
+import { aqiToRaw } from './aqiToRaw';
 import { pm25ToCigarettes } from './pm25ToCigarettes';
 
 /**

--- a/App/stores/fetchApi/dataSources/windWaqi.ts
+++ b/App/stores/fetchApi/dataSources/windWaqi.ts
@@ -16,8 +16,8 @@
 
 import axios from 'axios';
 
-import { aqiToRaw } from './aqiToRaw';
 import { LatLng } from '../../fetchGpsPosition';
+import { aqiToRaw } from './aqiToRaw';
 import { pm25ToCigarettes } from './pm25ToCigarettes';
 
 /**

--- a/App/stores/fetchApi/fetchApi.ts
+++ b/App/stores/fetchApi/fetchApi.ts
@@ -22,9 +22,9 @@ import * as TE from 'fp-ts/lib/TaskEither';
 import * as t from 'io-ts';
 import { failure } from 'io-ts/lib/PathReporter';
 
+import { retry, sideEffect, toError } from '../../util/fp';
 import { Location } from '../fetchGpsPosition';
 import * as dataSources from './dataSources';
-import { retry, sideEffect, toError } from '../../util/fp';
 
 const ApiT = t.type({
   aqi: t.number,

--- a/App/stores/fetchGpsPosition/fetchGpsPosition.ts
+++ b/App/stores/fetchGpsPosition/fetchGpsPosition.ts
@@ -18,6 +18,7 @@ import * as ExpoLocation from 'expo-location';
 import * as Permissions from 'expo-permissions';
 import { pipe } from 'fp-ts/lib/pipeable';
 import * as TE from 'fp-ts/lib/TaskEither';
+
 import { toError } from '../../util/fp';
 
 export interface LatLng {

--- a/App/stores/frequency.tsx
+++ b/App/stores/frequency.tsx
@@ -15,8 +15,8 @@
 // along with Sh**t! I Smoke.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { createContext, useState } from 'react';
-import { Frequency } from '../Screens/Home/SelectFrequency';
 
+import { Frequency } from '../Screens/Home/SelectFrequency';
 import { noop } from '../util/noop';
 
 interface Context {

--- a/App/stores/location.tsx
+++ b/App/stores/location.tsx
@@ -19,6 +19,8 @@ import * as T from 'fp-ts/lib/Task';
 import * as TE from 'fp-ts/lib/TaskEither';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
+import { logFpError } from '../util/fp';
+import { noop } from '../util/noop';
 import { ErrorContext } from './error';
 import {
   fetchGpsPosition,
@@ -26,8 +28,6 @@ import {
   LatLng,
   Location
 } from './fetchGpsPosition';
-import { logFpError } from '../util/fp';
-import { noop } from '../util/noop';
 
 const DEFAULT_LAT_LNG: LatLng = {
   latitude: 0,

--- a/App/util/fp.ts
+++ b/App/util/fp.ts
@@ -17,8 +17,8 @@
 import * as E from 'fp-ts/lib/Either';
 import * as IO from 'fp-ts/lib/IO';
 import * as O from 'fp-ts/lib/Option';
-import * as TE from 'fp-ts/lib/TaskEither';
 import { pipe } from 'fp-ts/lib/pipeable';
+import * as TE from 'fp-ts/lib/TaskEither';
 import { capDelay, limitRetries, RetryStatus } from 'retry-ts';
 import { retrying } from 'retry-ts/lib/Task';
 import * as Sentry from 'sentry-expo';

--- a/App/util/station.ts
+++ b/App/util/station.ts
@@ -15,9 +15,10 @@
 // along with Sh**t! I Smoke.  If not, see <http://www.gnu.org/licenses/>.
 
 import haversine from 'haversine';
+
+import { DistanceUnit } from '../stores/distanceUnit';
 import { Api } from '../stores/fetchApi';
 import { LatLng } from '../stores/fetchGpsPosition';
-import { DistanceUnit } from '../stores/distanceUnit';
 
 // Above this distance (km), we consider the station too far from the user
 export const MAX_DISTANCE_TO_STATION = 10;

--- a/package.json
+++ b/package.json
@@ -60,10 +60,11 @@
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
+    "eslint-plugin-simple-import-sort": "4.0.0",
     "jest": "^24.9.0",
     "jest-expo": "^35.0.0",
+    "prettier": "^1.18.2",
     "ts-jest": "^24.1.0",
-    "typescript": "^3.6.4",
-    "prettier": "^1.18.2"
+    "typescript": "^3.6.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,6 +2041,11 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+  integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -2746,6 +2751,13 @@ eslint-plugin-react@^7.16.0:
     object.values "^1.1.0"
     prop-types "^15.7.2"
     resolve "^1.12.0"
+
+eslint-plugin-simple-import-sort@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-4.0.0.tgz#048736c170b9b43f0a8c3ef85ba53881c389f3ff"
+  integrity sha512-QsxOMrXhhqvSiTmZafPc/lvSET9lhblaO2kaaSbFo1FVU/AW9mFQDXadiHJ5OqG6i0N6+Qd+RZ95iQbkg4p+0w==
+  dependencies:
+    validate-npm-package-name "^3.0.0"
 
 eslint-scope@^4.0.0:
   version "4.0.3"
@@ -7777,6 +7789,13 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
+  dependencies:
+    builtins "^1.0.3"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
- [x] Add [eslint-plugin-simple-import-sort](https://www.npmjs.com/package/eslint-plugin-simple-import-sort) plugin
- [x] Fix lint errors

[eslint-plugin-simple-import-sort](https://www.npmjs.com/package/eslint-plugin-simple-import-sort) has almost same rules of [contributing guide rules](https://github.com/amaurymartiny/shoot-i-smoke/blob/master/CONTRIBUTING.md#imports-ordering), only difference I saw is adding a blank line between dependencies imports and project imports.