### PR TITLE
fix: Remove useless Algolia community keys

### DIFF
--- a/App/Screens/Search/fetchAlgolia.ts
+++ b/App/Screens/Search/fetchAlgolia.ts
@@ -16,7 +16,6 @@
 
 import { LatLng } from '@shootismoke/dataproviders';
 import axios from 'axios';
-import Constants from 'expo-constants';
 import * as C from 'fp-ts/lib/Console';
 import * as E from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
@@ -92,17 +91,6 @@ export function fetchAlgolia(
                   query: search
                 },
                 {
-                  headers:
-                    Constants.manifest.extra.algoliaApplicationId &&
-                    Constants.manifest.extra.algoliaApiKey
-                      ? {
-                          'X-Algolia-Application-Id':
-                            Constants.manifest.extra.algoliaApplicationId,
-                          'X-Algolia-API-Key':
-                            Constants.manifest.extra.algoliaApiKey
-                        }
-                      : undefined,
-
                   timeout: 3000
                 }
               ),

--- a/App/util/amplitude.ts
+++ b/App/util/amplitude.ts
@@ -58,7 +58,7 @@ export type AmplitudeEvent =
   | 'ERROR_SCREEN_CHANGE_LOCATION_CLICK';
 
 export function setupAmplitude(): Promise<void> {
-  return Constants.manifest.extra.amplitudeApiKey
+  return typeof Constants.manifest.extra.amplitudeApiKey === 'string'
     ? Amplitude.initialize(Constants.manifest.extra.amplitudeApiKey).then(
         () => {
           Amplitude.setUserProperties({
@@ -84,7 +84,7 @@ export function track(
   event: AmplitudeEvent,
   properties?: Record<string, Json>
 ): void {
-  if (!Constants.manifest.extra.amplitudeApiKey) {
+  if (typeof Constants.manifest.extra.amplitudeApiKey !== 'string') {
     return;
   }
 

--- a/App/util/constants.ts
+++ b/App/util/constants.ts
@@ -39,4 +39,5 @@ export const IS_PROD =
  */
 export const IS_SENTRY_SET_UP =
   // We also added sentry on staging btw
-  (IS_PROD || IS_STAGING) && !!Constants.manifest.extra.sentryPublicDsn;
+  (IS_PROD || IS_STAGING) &&
+  typeof Constants.manifest.extra.sentryPublicDsn === 'string';

--- a/README.md
+++ b/README.md
@@ -80,15 +80,14 @@ The [Expo](https://expo.io) packager will show, and you can either:
 
 All required API tokens are already pre-filled in `app.example.json`. If you want to use your own API tokens, then in `app.json`, replace all the placeholders with the ones you generated for yourself. For those that are optional, you can just put `null` (without quotes).
 
-| Service                  | Url                                                                        | Comments                                                                    |
-| ------------------------ | -------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Sh\*\*t! I Smoke Backend | https://github.com/shootismoke/backend                                     | Required. Pre-filled with a staging token.                                  |
-| World Air Quality Index  | http://aqicn.org/api/                                                      | Required. You can use the public one in `app.example.json` for development. |
-| Algolia Places           | https://community.algolia.com/places/ (`Get Started` button on the bottom) | Optional, lower API rates if not provided.                                  |
-| Google Maps for iOS      | https://developers.google.com/maps/documentation/ios-sdk/start             | Optional in development.                                                    |
-| Google Maps for Android  | https://developers.google.com/maps/documentation/android-api/              | Optional in development.                                                    |
-| Sentry Bug Tracking      | https://sentry.io                                                          | Optional.                                                                   |
-| Amplitude Analytics      | https://amplitude.com                                                      | Optional. Note: we **never** track PII.                                     |
+| Service                  | Url                                                            | Comments                                                                    |
+| ------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Sh\*\*t! I Smoke Backend | https://github.com/shootismoke/backend                         | Required. Pre-filled with a staging token.                                  |
+| World Air Quality Index  | http://aqicn.org/api/                                          | Required. You can use the public one in `app.example.json` for development. |
+| Google Maps for iOS      | https://developers.google.com/maps/documentation/ios-sdk/start | Optional in development.                                                    |
+| Google Maps for Android  | https://developers.google.com/maps/documentation/android-api/  | Optional in development.                                                    |
+| Sentry Bug Tracking      | https://sentry.io                                              | Optional.                                                                   |
+| Amplitude Analytics      | https://amplitude.com                                          | Optional. Note: we **never** track PII.                                     |
 
 ## :raising_hand: Contribute
 

--- a/app.example.json
+++ b/app.example.json
@@ -14,8 +14,6 @@
     "assetBundlePatterns": ["assets/**/*"],
     "backgroundColor": "#FAFAFC",
     "extra": {
-      "algoliaApiKey": null,
-      "algoliaApplicationId": null,
       "aqicnToken": "6bb4237574756ba29f05cea553bd22576596c11e",
       "amplitudeApiKey": null,
       "hawkKey": "26bb8794-8f1e-4bf7-b977-081186af58d6",


### PR DESCRIPTION
Somehow, when i put `null` in the manifest.extra object, it shows as an empty object `{}` in Constants.manifest.extra.*